### PR TITLE
Fixed the Repository.json added a missing comma

### DIFF
--- a/RespecWrath/Repository.json
+++ b/RespecWrath/Repository.json
@@ -5,7 +5,7 @@
             "Id": "v1.06.2",
             "Version": "1.06.2",
             "DownloadUrl": "https://github.com/BarleyFlour/RespecMod/releases/download/v1.06.2/RespecWrath.zip"
-        }
+        },
         {
             "Id": "v1.06.3",
             "Version": "1.06.3",


### PR DESCRIPTION
Fixing a missing comma that causes a exception when the unityModManager tries to update the RespecMod
![image](https://user-images.githubusercontent.com/25915095/135729885-dc98ec69-f282-460f-8942-dfdcba92f329.png)
