### PR TITLE
add more null checks

### DIFF
--- a/RespecWrath/Main.cs
+++ b/RespecWrath/Main.cs
@@ -914,30 +914,20 @@ namespace RespecWrath
             {
                 Main.logger.Log("Library data gathering initiated");
                 DeityBackground.DeityFeatures = DeityBackground.DeitySelect?.AllFeatures.Select(a => a).ToArray();
-                var tempbackgroundlist = new List<BlueprintFeature>();
-                tempbackgroundlist.Add(DeityBackground.BackgroundSelect);
-                foreach (var background in DeityBackground.BackgroundSelect?.AllFeatures)
+                List<BlueprintFeature> tempbackgroundlist = [DeityBackground.BackgroundSelect];
+                foreach (var background in DeityBackground.BackgroundSelect?.AllFeatures.NotNull())
                 {
-                    if (background != null)
+                    tempbackgroundlist.Add(background);
+                    if (background is BlueprintFeatureSelection background1)
                     {
-                        tempbackgroundlist.Add(background);
-                        if (background.GetType() == typeof(BlueprintFeatureSelection))
+                        foreach (var selection in background1?.AllFeatures.NotNull())
                         {
-                            foreach (var selection in ((BlueprintFeatureSelection)background)?.AllFeatures)
+                            tempbackgroundlist.Add(selection);
+                            if (selection is BlueprintFeatureSelection selection1)
                             {
-                                if (selection != null)
+                                foreach (var selection2 in selection1?.AllFeatures.NotNull())
                                 {
-                                    tempbackgroundlist.Add(selection);
-                                    if (selection.GetType() == typeof(BlueprintFeatureSelection))
-                                    {
-                                        foreach (var selection2 in ((BlueprintFeatureSelection)selection)?.AllFeatures)
-                                        {
-                                            if (selection2 != null)
-                                            {
-                                                tempbackgroundlist.Add(selection2);
-                                            }
-                                        }
-                                    }
+                                        tempbackgroundlist.Add(selection2);
                                 }
                             }
                         }

--- a/RespecWrath/Main.cs
+++ b/RespecWrath/Main.cs
@@ -915,17 +915,17 @@ namespace RespecWrath
                 Main.logger.Log("Library data gathering initiated");
                 DeityBackground.DeityFeatures = DeityBackground.DeitySelect?.AllFeatures.Select(a => a).ToArray();
                 List<BlueprintFeature> tempbackgroundlist = [DeityBackground.BackgroundSelect];
-                foreach (var background in DeityBackground.BackgroundSelect?.AllFeatures.NotNull())
+                foreach (var background in DeityBackground.BackgroundSelect?.AllFeatures.NotNull() ?? [])
                 {
                     tempbackgroundlist.Add(background);
                     if (background is BlueprintFeatureSelection background1)
                     {
-                        foreach (var selection in background1?.AllFeatures.NotNull())
+                        foreach (var selection in background1?.AllFeatures.NotNull() ?? [])
                         {
                             tempbackgroundlist.Add(selection);
                             if (selection is BlueprintFeatureSelection selection1)
                             {
-                                foreach (var selection2 in selection1?.AllFeatures.NotNull())
+                                foreach (var selection2 in selection1?.AllFeatures.NotNull() ?? [])
                                 {
                                         tempbackgroundlist.Add(selection2);
                                 }

--- a/RespecWrath/Main.cs
+++ b/RespecWrath/Main.cs
@@ -925,12 +925,18 @@ namespace RespecWrath
                         {
                             foreach (var selection in ((BlueprintFeatureSelection)background)?.AllFeatures)
                             {
-                                tempbackgroundlist.Add(selection);
-                                if (selection.GetType() == typeof(BlueprintFeatureSelection))
+                                if (selection != null)
                                 {
-                                    foreach (var selection2 in ((BlueprintFeatureSelection)selection)?.AllFeatures)
+                                    tempbackgroundlist.Add(selection);
+                                    if (selection.GetType() == typeof(BlueprintFeatureSelection))
                                     {
-                                        tempbackgroundlist.Add(selection2);
+                                        foreach (var selection2 in ((BlueprintFeatureSelection)selection)?.AllFeatures)
+                                        {
+                                            if (selection2 != null)
+                                            {
+                                                tempbackgroundlist.Add(selection2);
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
People in Discord were showing an error of 

```
[RespecWrath] Error while gathering library data
[RespecWrath] System.NullReferenceException: Object reference not set to an instance of an object
  at RespecWrath.Main.PatchLibrary () [0x001ba] in 
```

With some logging, apparently `selection.GetType()` was returning Null, so I assume somehow they had a Null in the selection somehow.

Adding a Null check before adding it appears to have fixed the error and allowed the user to go through the respec process successfully. So then I added a Null check to the second selection as well, just incase. 

Not sure if this will have ramifications later on for the user though 